### PR TITLE
fix(ui): resolve bottom overflow issues in mood entry screens

### DIFF
--- a/lib/screens/add_mood_screen.dart
+++ b/lib/screens/add_mood_screen.dart
@@ -159,7 +159,7 @@ class _AddMoodScreenState extends State<AddMoodScreen> {
             ),
         ],
       ),
-      body: Padding(
+      body: SingleChildScrollView(
         padding: const EdgeInsets.all(16.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -169,6 +169,8 @@ class _AddMoodScreenState extends State<AddMoodScreen> {
             if (_analysisResult != null) _buildAnalysisCard(),
             if (_analysisResult != null) const SizedBox(height: 16),
             if (_analysisResult != null) _buildAdviceCard(),
+            // 添加底部额外空间，避免内容贴底
+            const SizedBox(height: 24),
           ],
         ),
       ),

--- a/lib/screens/edit_mood_screen.dart
+++ b/lib/screens/edit_mood_screen.dart
@@ -67,7 +67,7 @@ class _EditMoodScreenState extends State<EditMoodScreen> {
             ),
         ],
       ),
-      body: Padding(
+      body: SingleChildScrollView(
         padding: const EdgeInsets.all(16.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -77,6 +77,8 @@ class _EditMoodScreenState extends State<EditMoodScreen> {
             if (_analysisResult != null) _buildAnalysisCard(),
             if (_analysisResult != null) const SizedBox(height: 16),
             if (_analysisResult != null) _buildAdviceCard(),
+            // 添加底部额外空间，避免内容贴底
+            const SizedBox(height: 24),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
修复AddMoodScreen和EditMoodScreen中的底部溢出问题

## Changes
- 将AddMoodScreen的Column包装在SingleChildScrollView中，支持滚动
- 将EditMoodScreen的Column包装在SingleChildScrollView中，支持滚动  
- 添加底部额外间距，防止内容贴边

## Test Plan
- [x] 在AddMoodScreen中输入长文本并分析情绪，确认不再出现底部溢出
- [x] 在EditMoodScreen中编辑心情记录，确认界面可正常滚动
- [x] 验证页面滚动体验流畅

Fixes #1